### PR TITLE
Time sync

### DIFF
--- a/src/mavlink_receive.c
+++ b/src/mavlink_receive.c
@@ -64,6 +64,19 @@ static void mavlink_handle_msg_command_int(const mavlink_message_t *const msg)
   }
 }
 
+static void mavlink_handle_msg_timesync(const mavlink_message_t *const msg)
+{
+  uint32_t now_us = micros();
+
+  mavlink_timesync_t tsync;
+  mavlink_msg_timesync_decode(msg, &tsync);
+
+  if (tsync.tc1 == 0) // check that this is a request, not a response
+  {
+    mavlink_msg_timesync_send(MAVLINK_COMM_0, (int64_t) now_us*1000, tsync.ts1);
+  }
+}
+
 static void mavlink_handle_msg_offboard_control(const mavlink_message_t *const msg)
 {
   _offboard_control_time = micros();
@@ -135,6 +148,9 @@ static void handle_mavlink_message(void)
     break;
   case MAVLINK_MSG_ID_COMMAND_INT:
     mavlink_handle_msg_command_int(&in_buf);
+    break;
+  case MAVLINK_MSG_ID_TIMESYNC:
+    mavlink_handle_msg_timesync(&in_buf);
     break;
   default:
     break;

--- a/src/mavlink_stream.c
+++ b/src/mavlink_stream.c
@@ -34,7 +34,8 @@ static void mavlink_send_imu(void)
                              _accel_data[2],
                              _gyro_data[0],
                              _gyro_data[1],
-                             _gyro_data[2]);
+                             _gyro_data[2],
+                             0.0);
 }
 
 static void mavlink_send_servo_output_raw(void)

--- a/src/mavlink_stream.c
+++ b/src/mavlink_stream.c
@@ -28,6 +28,7 @@ static void mavlink_send_heartbeat(void)
 static void mavlink_send_imu(void)
 {
   mavlink_msg_small_imu_send(MAVLINK_COMM_0,
+                             mpuMeasurementTime,
                              _accel_data[0],
                              _accel_data[1],
                              _accel_data[2],
@@ -54,7 +55,7 @@ static void mavlink_send_servo_output_raw(void)
 static void mavlink_send_rc_raw(void)
 {
   mavlink_msg_rc_channels_send(MAVLINK_COMM_0,
-                               micros(),
+                               millis(),
                                0,
                                pwmRead(0),
                                pwmRead(1),


### PR DESCRIPTION
Implemented time synchronization modeled after mavros and the PX4.

Time synchronization currently works for message types that include a time stamp. It would also be possible to estimate the delay and subtract that off of the time other, non time-stamped messages are received to make the resulting ROS time stamp a little more accurate, but I have not done that yet.

Closes #11.