### PR TITLE
[WIP] Make onboard bias calibration play nice with temperature calibration

### DIFF
--- a/src/sensors.c
+++ b/src/sensors.c
@@ -67,19 +67,22 @@ static bool update_imu(void)
     {
       static int16_t acc_count = 0;
       static int32_t acc_sum[3] = {0, 0, 0};
+      static int32_t acc_temp_sum = 0;
       acc_sum[0] += _accel_data[0];
       acc_sum[1] += _accel_data[1];
       acc_sum[2] += ((_accel_data[2]*_accel_scale)-9806650)/_accel_scale;
+      acc_temp_sum += _imu_temperature;
       acc_count++;
       if (acc_count > 100)
       {
-        _params.values[PARAM_ACC_X_BIAS] = acc_sum[0]/acc_count;
-        _params.values[PARAM_ACC_Y_BIAS] = acc_sum[1]/acc_count;
-        _params.values[PARAM_ACC_Z_BIAS] = acc_sum[2]/acc_count;
+        _params.values[PARAM_ACC_X_BIAS] = (acc_sum[0] - _params.values[PARAM_ACC_X_TEMP_COMP]*acc_temp_sum/1000)/acc_count;
+        _params.values[PARAM_ACC_Y_BIAS] = (acc_sum[1] - _params.values[PARAM_ACC_Y_TEMP_COMP]*acc_temp_sum/1000)/acc_count;
+        _params.values[PARAM_ACC_Z_BIAS] = (acc_sum[2] - _params.values[PARAM_ACC_Z_TEMP_COMP]*acc_temp_sum/1000)/acc_count;
         acc_count = 0;
         acc_sum[0] = 0;
         acc_sum[1] = 0;
         acc_sum[2] = 0;
+        acc_temp_sum = 0;
         calib_acc = false;
         // we could do some sanity checking here if we wanted to.
       }


### PR DESCRIPTION
This fixes an issue where the bias offset from the onboard calibration is not compatible with the offset from the temperature calibration.

The reason is that the temperature calibration computes what the offset would be at 0degC, while the onboard calibration computes it at whatever the current temperature is. There are two possible ways to fix this:

1. Change the temperature compensation to use a bias offset computed at an arbitrary value (so instead of `bias = bias_0 + m*T`, we would have `bias = bias_c +  m*(T - T_c)`. This is probably the more intuitive solution, but requires storing another parameter and an additional subtraction at each time step. Also requires a slight tweak to the least squares stuff, but it's not bad at all.
2. Modify the onboard bias calibration to estimate the bias at temperature 0 based on the current slope (so instead of `bias_0 = bias_c`, we have `bias_0 = bias_c - m*T_c`). Less intuitive, but eliminates the need to store `T_c` and the extra subtraction is done only once.

I've implemented option 2 here, and it seems to work pretty well. Running the temperature calibration then the onboard calibration immediately after results in the same offsets, where before they would change. I'm also open to doing 1 instead if you think the clarity is worth the cost.

With that said, the z offset still isn't quite right. I come in at about 9.6m/s^2 instead of 9.8. Would you mind testing yours for comparison?