### PR TITLE
Added printf like support for mavlink STATUSTEXT messages

### DIFF
--- a/include/mavlink_log.h
+++ b/include/mavlink_log.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <breezystm32/breezystm32.h>
+
+#include "mavlink.h"
+
+#define mavlink_log(severity, format, ...) do { \
+  char text[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN]; \
+  sprintf(text, format, ##__VA_ARGS__); \
+  mavlink_msg_statustext_send(MAVLINK_COMM_0, severity, text); \
+  } while (0)
+
+#define mavlink_log_critical(format, ...) mavlink_log(MAV_SEVERITY_CRITICAL, format, ##__VA_ARGS__)
+#define mavlink_log_error(format, ...)    mavlink_log(MAV_SEVERITY_ERROR,    format, ##__VA_ARGS__)
+#define mavlink_log_warning(format, ...)  mavlink_log(MAV_SEVERITY_WARNING,  format, ##__VA_ARGS__)
+#define mavlink_log_info(format, ...)     mavlink_log(MAV_SEVERITY_INFO,     format, ##__VA_ARGS__)


### PR DESCRIPTION
Closes #19.

One warning though: these statustext messages are big and don't get buffered onboard, so use them sparingly!