### PR TITLE
Float estimator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,8 @@ clean:
 	rm -rf $(TARGET_HEX) $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP) $(BIN_DIR) $(OBJECT_DIR)
 
 flash_$(TARGET): $(TARGET_HEX)
-	stty -F $(SERIAL_DEVICE) raw speed 115200 -crtscts cs8 -parenb -cstopb -ixon
-	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 115200 $(SERIAL_DEVICE)
+	stty -F $(SERIAL_DEVICE) raw speed 921600 -crtscts cs8 -parenb -cstopb -ixon
+	stm32flash -w $(TARGET_HEX) -v -g 0x0 -b 921600 $(SERIAL_DEVICE)
 
 flash: flash_$(TARGET)
 

--- a/include/estimator.h
+++ b/include/estimator.h
@@ -10,12 +10,12 @@ extern "C" {
 
 typedef struct
 {
-  int32_t p;
-  int32_t q;
-  int32_t r;
-  int32_t phi;
-  int32_t theta;
-  int32_t psi;
+  float p;
+  float q;
+  float r;
+  float phi;
+  float theta;
+  float psi;
 } state_t;
 
 extern vector_t _adaptive_gyro_bias;

--- a/lib/turbotrig/turbotrig.c
+++ b/lib/turbotrig/turbotrig.c
@@ -116,6 +116,22 @@ int32_t sign(int32_t y)
   return (0 < y) - (y < 0);
 }
 
+float atan2_approx(float y, float x)
+{
+  int32_t x_int, y_int;
+  x_int = (int32_t)(1000*x);
+  y_int = (int32_t)(1000*y);
+  float out = ((float)turboatan2(y_int, x_int))/1000.0f;
+  return out;
+}
+
+float asin_approx(float x)
+{
+  int32_t x_int = (int32_t)(1000*x);
+  float out = ((float)turboasin(x_int))/1000.0f;
+  return out;
+}
+
 
 int32_t turboatan(int32_t x)
 {

--- a/lib/turbotrig/turbotrig.h
+++ b/lib/turbotrig/turbotrig.h
@@ -5,6 +5,11 @@ extern "C" {
 
 #include <stdint.h>
 
+// float-based wrappers
+float atan2_approx(float y, float x);
+float asin_approx(float x);
+
+// turbo-speed trig approximation
 int32_t turboatan2(int32_t y, int32_t x);
 int32_t turboatan(int32_t x);
 int32_t turboasin(int32_t x);

--- a/lib/turbotrig/turbovec.c
+++ b/lib/turbotrig/turbovec.c
@@ -213,7 +213,9 @@ quaternion_t quaternion_multiply(quaternion_t q1, quaternion_t q2)
 
 quaternion_t quaternion_inverse(quaternion_t q)
 {
-  q.w *= -1.0f;
+  q.x *= -1.0f;
+  q.y *= -1.0f;
+  q.z *= -1.0f;
   return q;
 }
 
@@ -225,13 +227,13 @@ quaternion_t quat_from_two_vectors(vector_t u, vector_t v)
   return quaternion_normalize(q);
 }
 
-void euler_from_quat(quaternion_t q, int32_t *phi, int32_t *theta, int32_t *psi)
+void euler_from_quat(quaternion_t q, float *phi, float *theta, float *psi)
 {
-  *phi = turboatan2((int32_t)(2000*(q.w*q.x + q.y*q.z)),
-                    (int32_t)(1000 - 2000*(q.x*q.x + q.y*q.y)));
-  *theta = turboasin((int32_t)(2000*(q.w*q.y - q.z*q.x)));
-  *psi = turboatan2((int32_t)(2000*(q.w*q.z + q.x*q.y)),
-                    (int32_t)(1000-2000*(q.y*q.y + q.z*q.z)));
+  *phi = atan2_approx(2.0f * (q.w*q.x + q.y*q.z),
+                      1.0f - 2.0f * (q.x*q.x + q.y*q.y));
+  *theta = asin_approx(2.0f*(q.w*q.y - q.z*q.x));
+  *psi = atan2_approx(2.0f * (q.w*q.z + q.x*q.y),
+                     1.0f - 2.0f * (q.y*q.y + q.z*q.z));
 }
 
 

--- a/lib/turbotrig/turbovec.h
+++ b/lib/turbotrig/turbovec.h
@@ -60,7 +60,7 @@ quaternion_t quaternion_multiply(quaternion_t q1, quaternion_t q2);
 quaternion_t quaternion_inverse(quaternion_t q);
 quaternion_t quat_from_two_vectors(vector_t u, vector_t v);
 
-void euler_from_quat(quaternion_t q, int32_t *phi, int32_t *theta, int32_t *psi);
+void euler_from_quat(quaternion_t q, float *phi, float *theta, float *psi);
 void euler_from_int_quat(intquat_t q, int32_t phi, int32_t theta, int32_t psi);
 
 float turboInvSqrt(float x);

--- a/src/estimator.c
+++ b/src/estimator.c
@@ -67,8 +67,8 @@ void init_estimator(bool use_matrix_exponential, bool use_quadratic_integration,
   b.y = 0.0f;
   b.z = 0.0f;
 
-  kp_ = ((float)_params.values[PARAM_FILTER_KP])/1000.0f;
-  ki_ = ((float)_params.values[PARAM_FILTER_KI])/1000.0f;
+  kp_ = get_param_float(PARAM_FILTER_KP);
+  ki_ = get_param_float(PARAM_FILTER_KI);
   init_time = _params.values[PARAM_INIT_TIME]*1000; // microseconds
 
   w_acc.x = 0.0f;

--- a/src/estimator.c
+++ b/src/estimator.c
@@ -218,12 +218,9 @@ void run_estimator(uint32_t now)
   _current_state.r = (1.0-alpha)*wbar.z + alpha*_current_state.r;
 
   // Save gyro biases for streaming to computer
-  if (_params.values[PARAM_STREAM_ADJUSTED_GYRO])
-  {
-    _adaptive_gyro_bias.x = b.x;
-    _adaptive_gyro_bias.y = b.y;
-    _adaptive_gyro_bias.z = b.z;
-  }
+  _adaptive_gyro_bias.x = b.x;
+  _adaptive_gyro_bias.y = b.y;
+  _adaptive_gyro_bias.z = b.z;
 }
 
 #ifdef __cplusplus

--- a/src/estimator.c
+++ b/src/estimator.c
@@ -16,8 +16,6 @@ extern "C" {
 
 #include "estimator.h"
 
-#define PF(a) ((int32_t)(a*1000.0f))
-
 state_t _current_state;
 vector_t _adaptive_gyro_bias;
 

--- a/src/estimator.c
+++ b/src/estimator.c
@@ -217,10 +217,6 @@ void run_estimator(uint32_t now)
   _current_state.q = (1.0-alpha)*wbar.y + alpha*_current_state.q;
   _current_state.r = (1.0-alpha)*wbar.z + alpha*_current_state.r;
 
-  mavlink_send_named_value_float("phi", _current_state.phi);
-  mavlink_send_named_value_float("theta", _current_state.theta);
-  mavlink_send_named_value_float("psi", _current_state.psi);
-
   // Save gyro biases for streaming to computer
   if (_params.values[PARAM_STREAM_ADJUSTED_GYRO])
   {

--- a/src/estimator.c
+++ b/src/estimator.c
@@ -100,7 +100,7 @@ void run_estimator(uint32_t now)
     last_time = now;
     return;
   }
-  int32_t dt = now - last_time;
+  float dt = (now - last_time) * 1e-6f;
   last_time = now;
 
   // Crank up the gains for the first few seconds for quick convergence
@@ -136,9 +136,9 @@ void run_estimator(uint32_t now)
 
     // integrate biases from accelerometer feedback
     // (eq 47b Mahoney Paper, using correction term w_acc found above)
-    b.x -= ki*w_acc.x*(float)dt*1e-6;
-    b.y -= ki*w_acc.y*(float)dt*1e-6;
-    b.z -= ki*w_acc.z*(float)dt*1e-6;
+    b.x -= ki*w_acc.x*dt;
+    b.y -= ki*w_acc.y*dt;
+    b.z -= ki*w_acc.z*dt;
   }
   else
   {
@@ -182,8 +182,8 @@ void run_estimator(uint32_t now)
       // This adds 66 us on STM32F10x chips
       float norm_w = sqrt(sqrd_norm_w);
       quaternion_t qhat_np1;
-      float t1 = cos((norm_w*dt*1e-6)/2.0f);
-      float t2 = 1.0/norm_w * sin((norm_w*dt*1e-6)/2.0f);
+      float t1 = cos((norm_w*dt)/2.0f);
+      float t2 = 1.0/norm_w * sin((norm_w*dt)/2.0f);
       qhat_np1.w = t1*q_hat.w   + t2*(          - p*q_hat.x - q*q_hat.y - r*q_hat.z);
       qhat_np1.x = t1*q_hat.x   + t2*(p*q_hat.w             + r*q_hat.y - q*q_hat.z);
       qhat_np1.y = t1*q_hat.y   + t2*(q*q_hat.w - r*q_hat.x             + p*q_hat.z);
@@ -199,10 +199,10 @@ void run_estimator(uint32_t now)
                            0.5 * ( q*q_hat.w - r*q_hat.x             + p*q_hat.z),
                            0.5 * ( r*q_hat.w + q*q_hat.x - p*q_hat.y)
                           };
-      q_hat.w += qdot.w*(float)dt*1e-6;
-      q_hat.x += qdot.x*(float)dt*1e-6;
-      q_hat.y += qdot.y*(float)dt*1e-6;
-      q_hat.z += qdot.z*(float)dt*1e-6;
+      q_hat.w += qdot.w*dt;
+      q_hat.x += qdot.x*dt;
+      q_hat.y += qdot.y*dt;
+      q_hat.z += qdot.z*dt;
       q_hat = quaternion_normalize(q_hat);
     }
   }

--- a/src/estimator.c
+++ b/src/estimator.c
@@ -16,7 +16,7 @@ extern "C" {
 
 #include "estimator.h"
 
-#define PF(a) ((int32_t)(a*1000.0))
+#define PF(a) ((int32_t)(a*1000.0f))
 
 state_t _current_state;
 vector_t _adaptive_gyro_bias;
@@ -118,7 +118,7 @@ void run_estimator(uint32_t now)
   // add in accelerometer
   float a_sqrd_norm = _accel.x*_accel.x + _accel.y*_accel.y + _accel.z*_accel.z;
 
-  if (use_acc && a_sqrd_norm < 1.15*1.15*9.80665*9.80665 && a_sqrd_norm > 0.85*0.85*9.80665*9.80665)
+  if (use_acc && a_sqrd_norm < 1.15f*1.15f*9.80665f*9.80665f && a_sqrd_norm > 0.85f*0.85f*9.80665f*9.80665f)
   {
     // Get error estimated by accelerometer measurement
     vector_t a = vector_normalize(_accel);
@@ -183,7 +183,7 @@ void run_estimator(uint32_t now)
       float norm_w = sqrt(sqrd_norm_w);
       quaternion_t qhat_np1;
       float t1 = cos((norm_w*dt)/2.0f);
-      float t2 = 1.0/norm_w * sin((norm_w*dt)/2.0f);
+      float t2 = 1.0f/norm_w * sin((norm_w*dt)/2.0f);
       qhat_np1.w = t1*q_hat.w   + t2*(          - p*q_hat.x - q*q_hat.y - r*q_hat.z);
       qhat_np1.x = t1*q_hat.x   + t2*(p*q_hat.w             + r*q_hat.y - q*q_hat.z);
       qhat_np1.y = t1*q_hat.y   + t2*(q*q_hat.w - r*q_hat.x             + p*q_hat.z);
@@ -194,10 +194,10 @@ void run_estimator(uint32_t now)
     {
       // Euler Integration
       // (Eq. 47a Mahoney Paper), but this is pretty straight-forward
-      quaternion_t qdot = {0.5 * (           - p*q_hat.x - q*q_hat.y - r*q_hat.z),
-                           0.5 * ( p*q_hat.w             + r*q_hat.y - q*q_hat.z),
-                           0.5 * ( q*q_hat.w - r*q_hat.x             + p*q_hat.z),
-                           0.5 * ( r*q_hat.w + q*q_hat.x - p*q_hat.y)
+      quaternion_t qdot = {0.5f * (           - p*q_hat.x - q*q_hat.y - r*q_hat.z),
+                           0.5f * ( p*q_hat.w             + r*q_hat.y - q*q_hat.z),
+                           0.5f * ( q*q_hat.w - r*q_hat.x             + p*q_hat.z),
+                           0.5f * ( r*q_hat.w + q*q_hat.x - p*q_hat.y)
                           };
       q_hat.w += qdot.w*dt;
       q_hat.x += qdot.x*dt;
@@ -212,10 +212,10 @@ void run_estimator(uint32_t now)
 
   // Save off gyro
   wbar = vector_sub(wbar, b);
-  float alpha = 0.8;
-  _current_state.p = (1.0-alpha)*wbar.x + alpha*_current_state.p;
-  _current_state.q = (1.0-alpha)*wbar.y + alpha*_current_state.q;
-  _current_state.r = (1.0-alpha)*wbar.z + alpha*_current_state.r;
+  float alpha = 0.8f;
+  _current_state.p = (1.0f-alpha)*wbar.x + alpha*_current_state.p;
+  _current_state.q = (1.0f-alpha)*wbar.y + alpha*_current_state.q;
+  _current_state.r = (1.0f-alpha)*wbar.z + alpha*_current_state.r;
 
   // Save gyro biases for streaming to computer
   _adaptive_gyro_bias.x = b.x;

--- a/src/main.c
+++ b/src/main.c
@@ -76,7 +76,7 @@ void setup(void)
   init_mixing();
 
   // Initialize Estimator
-  init_estimator(false, true, true);
+  init_estimator(true, true, true);
   init_mode();
 }
 

--- a/src/mavlink_stream.c
+++ b/src/mavlink_stream.c
@@ -32,12 +32,12 @@ static void mavlink_send_attitude(void)
 {
   mavlink_msg_attitude_send(MAVLINK_COMM_0,
                             millis(),
-                            (float)(_current_state.phi)/1000.0f,
-                            (float)(_current_state.theta)/1000.0f,
-                            (float)(_current_state.psi)/1000.0f,
-                            (float)(_current_state.p)/1000.0f,
-                            (float)(_current_state.q)/1000.0f,
-                            (float)(_current_state.r)/1000.0f);
+                            _current_state.phi,
+                            _current_state.theta,
+                            _current_state.psi,
+                            _current_state.p,
+                            _current_state.q,
+                            _current_state.r);
 }
 
 static void mavlink_send_imu(void)

--- a/src/mode.c
+++ b/src/mode.c
@@ -55,17 +55,14 @@ bool check_mode(uint32_t now)
           && pwmRead(_params.values[PARAM_RC_Z_CHANNEL]) > (_params.values[PARAM_RC_Z_CENTER] + _params.values[PARAM_RC_Z_RANGE]/2)
           - _params.values[PARAM_ARM_THRESHOLD])
       {
-        mavlink_send_named_value_int("check", 1);
         time_sticks_have_been_in_arming_position += dt;
       }
       else
       {
-        mavlink_send_named_value_int("check", 2);
         time_sticks_have_been_in_arming_position = 0;
       }
       if (time_sticks_have_been_in_arming_position > 500000)
       {
-        mavlink_send_named_value_int("check", 3);
         arm();
         time_sticks_have_been_in_arming_position = 0;
       }

--- a/src/param.c
+++ b/src/param.c
@@ -78,8 +78,8 @@ void set_param_defaults(void)
   init_param_int(PARAM_MAG_UPDATE, "MAG_UPDATE", 20000);
 
   init_param_int(PARAM_INIT_TIME, "FILTER_INIT_T", 3000); // ms
-  init_param_int(PARAM_FILTER_KP, "FILTER_KP", 1000); // munits
-  init_param_int(PARAM_FILTER_KI, "FILTER_KI", 100);  // munits
+  init_param_float(PARAM_FILTER_KP, "FILTER_KP", 1.0f);
+  init_param_float(PARAM_FILTER_KI, "FILTER_KI", 0.1f);
   init_param_int(PARAM_STREAM_ADJUSTED_GYRO, "STRM_ADJUST_GYRO", 0);
   init_param_float(PARAM_GYRO_X_BIAS, "GYRO_X_BIAS", 0.0f);
   init_param_float(PARAM_GYRO_Y_BIAS, "GYRO_Y_BIAS", 0.0f);

--- a/src/param.c
+++ b/src/param.c
@@ -54,7 +54,7 @@ void set_param_defaults(void)
     init_param_int(id, temp_name, id);
   }
 
-  init_param_int(PARAM_BOARD_REVISION, "BOARD_REV", 5);
+  init_param_int(PARAM_BOARD_REVISION, "BOARD_REV", 2);
 
   init_param_int(PARAM_BAUD_RATE, "BAUD_RATE", 921600);
 
@@ -80,7 +80,7 @@ void set_param_defaults(void)
   init_param_int(PARAM_INIT_TIME, "FILTER_INIT_T", 3000); // ms
   init_param_int(PARAM_FILTER_KP, "FILTER_KP", 1000); // munits
   init_param_int(PARAM_FILTER_KI, "FILTER_KI", 100);  // munits
-  init_param_int(PARAM_STREAM_ADJUSTED_GYRO, "STRM_ADJUST_GYRO", 1);
+  init_param_int(PARAM_STREAM_ADJUSTED_GYRO, "STRM_ADJUST_GYRO", 0);
   init_param_float(PARAM_GYRO_X_BIAS, "GYRO_X_BIAS", 0.0f);
   init_param_float(PARAM_GYRO_Y_BIAS, "GYRO_Y_BIAS", 0.0f);
   init_param_float(PARAM_GYRO_Z_BIAS, "GYRO_Z_BIAS", 0.0f);

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -1,5 +1,5 @@
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
 
 #include <stdbool.h>

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -138,10 +138,6 @@ static bool update_imu(void)
     _gyro.x -= get_param_float(PARAM_GYRO_X_BIAS);
     _gyro.y -= get_param_float(PARAM_GYRO_Y_BIAS);
     _gyro.z -= get_param_float(PARAM_GYRO_Z_BIAS);
-
-    mavlink_send_named_value_float("x_gyro", _gyro.x);
-    mavlink_send_named_value_float("y_gyro", _gyro.y);
-
     return true;
   }
   else

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -77,7 +77,7 @@ static bool update_imu(void)
     if (calib_acc)
     {
       static uint16_t acc_count = 0;
-      static vector_t acc_sum  = { .x = 0.0f, .y = 0.0f, .z = 0.0f };
+      static vector_t acc_sum  = { 0.0f, 0.0f, 0.0f };
       static float acc_temp_sum = 0.0f;
 
       acc_sum.x += _accel.x;
@@ -86,14 +86,14 @@ static bool update_imu(void)
       acc_temp_sum += _imu_temperature;
       acc_count++;
 
-      if (acc_count > 100)
+      if (acc_count > 1000)
       {
         set_param_by_id_float(PARAM_ACC_X_BIAS,
-                              (acc_sum.x - get_param_float(PARAM_ACC_X_TEMP_COMP) * acc_temp_sum) / acc_count);
+                              (acc_sum.x - get_param_float(PARAM_ACC_X_TEMP_COMP) * acc_temp_sum) / (float)acc_count);
         set_param_by_id_float(PARAM_ACC_Y_BIAS,
-                              (acc_sum.y - get_param_float(PARAM_ACC_Y_TEMP_COMP) * acc_temp_sum) / acc_count);
+                              (acc_sum.y - get_param_float(PARAM_ACC_Y_TEMP_COMP) * acc_temp_sum) / (float)acc_count);
         set_param_by_id_float(PARAM_ACC_Z_BIAS,
-                              (acc_sum.z - get_param_float(PARAM_ACC_Z_TEMP_COMP) * acc_temp_sum) / acc_count);
+                              (acc_sum.z - get_param_float(PARAM_ACC_Z_TEMP_COMP) * acc_temp_sum) / (float)acc_count);
 
         acc_count = 0;
         acc_sum.x = 0.0f;
@@ -108,18 +108,18 @@ static bool update_imu(void)
     if (calib_gyro)
     {
       static uint16_t gyro_count = 0;
-      static vector_t gyro_sum = { .x = 0.0f, .y = 0.0f, .z = 0.0f };
+      static vector_t gyro_sum = { 0.0f, 0.0f, 0.0f };
 
       gyro_sum.x += _gyro.x;
       gyro_sum.y += _gyro.y;
       gyro_sum.z += _gyro.z;
       gyro_count++;
 
-      if (gyro_count > 100)
+      if (gyro_count > 1000)
       {
-        set_param_by_id_float(PARAM_GYRO_X_BIAS, gyro_sum.x / gyro_count);
-        set_param_by_id_float(PARAM_GYRO_Y_BIAS, gyro_sum.y / gyro_count);
-        set_param_by_id_float(PARAM_GYRO_Z_BIAS, gyro_sum.z / gyro_count);
+        set_param_by_id_float(PARAM_GYRO_X_BIAS, gyro_sum.x / (float)gyro_count);
+        set_param_by_id_float(PARAM_GYRO_Y_BIAS, gyro_sum.y / (float)gyro_count);
+        set_param_by_id_float(PARAM_GYRO_Z_BIAS, gyro_sum.z / (float)gyro_count);
 
         gyro_count = 0;
         gyro_sum.x = 0.0f;
@@ -138,6 +138,9 @@ static bool update_imu(void)
     _gyro.x -= get_param_float(PARAM_GYRO_X_BIAS);
     _gyro.y -= get_param_float(PARAM_GYRO_Y_BIAS);
     _gyro.z -= get_param_float(PARAM_GYRO_Z_BIAS);
+
+    mavlink_send_named_value_float("x_gyro", _gyro.x);
+    mavlink_send_named_value_float("y_gyro", _gyro.y);
 
     return true;
   }
@@ -158,12 +161,13 @@ void init_sensors(void)
   // IMU
   _imu_ready = false;
   mpu6050_register_interrupt_cb(&imu_ISR);
-
   uint16_t acc1G;
-  float gyro_scale_to_urad;
-  mpu6050_init(true, &acc1G, &gyro_scale_to_urad, _params.values[PARAM_BOARD_REVISION]);
-  gyro_scale = 1000000.0*gyro_scale_to_urad;
+  float gyro_scale_to_Mrad;
+  mpu6050_init(true, &acc1G, &gyro_scale_to_Mrad, _params.values[PARAM_BOARD_REVISION]);
+  gyro_scale = gyro_scale_to_Mrad*1e6;
   accel_scale = 9.80665f/acc1G;
+  calib_gyro = true;
+  calib_acc = true;
 
   // DIFF PRESSURE
   _diff_pressure_present = ms4525_detect();
@@ -200,12 +204,18 @@ bool update_sensors(uint32_t time_us)
 bool calibrate_acc(void)
 {
   calib_acc = true;
+  set_param_by_id_float(PARAM_ACC_X_BIAS, 0.0);
+  set_param_by_id_float(PARAM_ACC_Y_BIAS, 0.0);
+  set_param_by_id_float(PARAM_ACC_Z_BIAS, 0.0);
   return true;
 }
 
 bool calibrate_gyro(void)
 {
   calib_gyro = true;
+  set_param_by_id_float(PARAM_GYRO_X_BIAS, 0.0);
+  set_param_by_id_float(PARAM_GYRO_Y_BIAS, 0.0);
+  set_param_by_id_float(PARAM_GYRO_Z_BIAS, 0.0);
   return true;
 }
 


### PR DESCRIPTION
Based on #51, so this pull request should be rebased on master once that request is finished.

This moves `_current_state` to be a float-based struct, represents some additional float-based turbotrig library wrappers.

I also cranked up the flash UART speed to 921600 because I'm tired of waiting forever to flash this thing.  

I tested it on my REV2 board, the estimator seems to be working great.  I found a typo in the matrix exponential method, so pitch is estimated correctly when using that method (we weren't using it previously)