### PR TITLE
Fixed a bunch of incorrect type castings

### DIFF
--- a/src/mavlink_param.c
+++ b/src/mavlink_param.c
@@ -45,7 +45,7 @@ void mavlink_handle_msg_param_request_read(const mavlink_message_t *const msg)
 
   if (read.target_system == (uint8_t) _params.values[PARAM_SYSTEM_ID]) // TODO check if component id matches?
   {
-    param_id_t id = (read.param_index < 0) ? lookup_param_id(read.param_id) : read.param_index;
+    param_id_t id = (read.param_index < 0) ? lookup_param_id(read.param_id) : (param_id_t) read.param_index;
 
     if (id < PARAMS_COUNT)
       mavlink_send_param(id);
@@ -97,7 +97,7 @@ void mavlink_send_next_param(void)
 {
   if (send_params_index < PARAMS_COUNT)
   {
-    mavlink_send_param(send_params_index);
+    mavlink_send_param((param_id_t) send_params_index);
     send_params_index++;
   }
 }

--- a/src/mavlink_stream.c
+++ b/src/mavlink_stream.c
@@ -139,18 +139,18 @@ static void mavlink_send_low_priority(void)
 // local variable definitions
 static mavlink_stream_t mavlink_streams[MAVLINK_STREAM_COUNT] =
 {
-  { .period_us = 1e6, .last_time_us = 0, .send_function = mavlink_send_heartbeat },
+  { .period_us = 1000000, .last_time_us = 0, .send_function = mavlink_send_heartbeat },
 
-  { .period_us = 2e5, .last_time_us = 0, .send_function = mavlink_send_attitude },
+  { .period_us = 200000,  .last_time_us = 0, .send_function = mavlink_send_attitude },
 
-  { .period_us = 1e3, .last_time_us = 0, .send_function = mavlink_send_imu },
-  { .period_us = 2e5, .last_time_us = 0, .send_function = mavlink_send_diff_pressure },
-  { .period_us = 2e5, .last_time_us = 0, .send_function = mavlink_send_baro },
-  { .period_us = 1e6, .last_time_us = 0, .send_function = mavlink_send_sonar },
+  { .period_us = 1000,    .last_time_us = 0, .send_function = mavlink_send_imu },
+  { .period_us = 200000,  .last_time_us = 0, .send_function = mavlink_send_diff_pressure },
+  { .period_us = 200000,  .last_time_us = 0, .send_function = mavlink_send_baro },
+  { .period_us = 100000,  .last_time_us = 0, .send_function = mavlink_send_sonar },
 
-  { .period_us = 0,   .last_time_us = 0, .send_function = mavlink_send_servo_output_raw },
-  { .period_us = 0,   .last_time_us = 0, .send_function = mavlink_send_rc_raw },
-  { .period_us = 1e4, .last_time_us = 0, .send_function = mavlink_send_low_priority }
+  { .period_us = 0,       .last_time_us = 0, .send_function = mavlink_send_servo_output_raw },
+  { .period_us = 0,       .last_time_us = 0, .send_function = mavlink_send_rc_raw },
+  { .period_us = 10000,   .last_time_us = 0, .send_function = mavlink_send_low_priority }
 };
 
 // function definitions

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -17,7 +17,7 @@ output_type_t _GPIO_output_type[8];
 
 static mixer_t quadcopter_plus_mixing =
 {
-  {M, M, M, M, 0, 0, 0, 0}, // output_type
+  {M, M, M, M, NONE, NONE, NONE, NONE}, // output_type
 
   { 1000,  1000,  1000,  1000, 0, 0, 0, 0}, // F Mix
   { 0,    -1000,  1000,  0,    0, 0, 0, 0}, // X Mix
@@ -28,7 +28,7 @@ static mixer_t quadcopter_plus_mixing =
 
 static mixer_t quadcopter_x_mixing =
 {
-  {M, M, M, M, 0, 0, 0, 0}, // output_type
+  {M, M, M, M, NONE, NONE, NONE, NONE}, // output_type
 
   { 1000, 1000, 1000, 1000,  0, 0, 0, 0}, // F Mix
   {-1000,-1000, 1000, 1000,  0, 0, 0, 0}, // X Mix
@@ -38,7 +38,7 @@ static mixer_t quadcopter_x_mixing =
 
 static mixer_t fixedwing_mixing =
 {
-  {S, S, M, S, 0, 0, 0, 0},
+  {S, S, M, S, NONE, NONE, NONE, NONE},
 
   {0,    0,    1000, 0,    0, 0, 0, 0}, // F Mix
   {1000, 0,    0,    0,    0, 0, 0, 0}, // X Mix
@@ -48,7 +48,7 @@ static mixer_t fixedwing_mixing =
 
 static mixer_t tricopter_mixing =
 {
-  {M, M, M, S, 0, 0, 0, 0},
+  {M, M, M, S, NONE, NONE, NONE, NONE},
 
   {1000,  1000, 1000, 0,    0, 0, 0, 0}, // F Mix
   {-1000, 1000, 0,    0,    0, 0, 0, 0}, // X Mix
@@ -58,7 +58,7 @@ static mixer_t tricopter_mixing =
 
 static mixer_t Y6_mixing =
 {
-  {M, M, M, M, M, M, 0, 0},
+  {M, M, M, M, M, M, NONE, NONE},
   { 1000, 1000, 1000, 1000, 1000, 1000, 0, 0}, // F Mix
   { 0,   -1000, 1000, 0,   -1000, 1000, 0, 0}, // X Mix
   {-1300,  667,  667,-1300,  667,  667, 0, 0}, // Y Mix

--- a/src/param.c
+++ b/src/param.c
@@ -42,18 +42,18 @@ void init_params(void)
     write_params();
   }
 
-  for (param_id_t id = 0; id < PARAMS_COUNT; id++)
-    param_change_callback(id);
+  for (uint16_t id = 0; id < PARAMS_COUNT; id++)
+    param_change_callback((param_id_t) id);
 }
 
 void set_param_defaults(void)
 {
   // temporary: replace with actual initialisation of rest of params
   char temp_name[PARAMS_NAME_LENGTH];
-  for (param_id_t id = 0; id < PARAMS_COUNT; id++)
+  for (uint16_t id = 0; id < PARAMS_COUNT; id++)
   {
     sprintf(temp_name, "TEMP_%c%c", 'A' + id/10, 'A' + id%10);
-    init_param_int(id, temp_name, id);
+    init_param_int((param_id_t) id, temp_name, id);
   }
 
   init_param_int(PARAM_BOARD_REVISION, "BOARD_REV", 2);
@@ -216,7 +216,7 @@ void param_change_callback(param_id_t id)
 
 param_id_t lookup_param_id(const char name[PARAMS_NAME_LENGTH])
 {
-  for (param_id_t id = 0; id < PARAMS_COUNT; id++)
+  for (uint16_t id = 0; id < PARAMS_COUNT; id++)
   {
     bool match = true;
     for (uint8_t i = 0; i < PARAMS_NAME_LENGTH; i++)
@@ -234,7 +234,7 @@ param_id_t lookup_param_id(const char name[PARAMS_NAME_LENGTH])
     }
 
     if (match)
-      return id;
+      return (param_id_t) id;
   }
 
   return PARAMS_COUNT;
@@ -254,7 +254,7 @@ bool set_param_by_id(param_id_t id, int32_t value)
 
 bool set_param_by_name(const char name[PARAMS_NAME_LENGTH], int32_t value)
 {
-  uint8_t id = lookup_param_id(name);
+  param_id_t id = lookup_param_id(name);
   return set_param_by_id(id, value);
 }
 


### PR DESCRIPTION
I was messing around with compiler settings, and found a bunch of implicit type casts going on that are technically incorrect, although they probably weren't causing any problems. This fixes them though. Also using the ++ operator on an enum is technically undefined, so I got rid of those too.