### PR TITLE
Disable pedantic warnings only for mavlink_types.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ CFLAGS		 = $(ARCH_FLAGS) \
 		   $(addprefix -D,$(OPTIONS)) \
 		   $(addprefix -I,$(INCLUDE_DIRS)) \
 		   $(DEBUG_FLAGS) \
-		   -Wall -Wno-pedantic -Wextra -Wshadow -Wunsafe-loop-optimizations \
+		   -Wall -pedantic -Wextra -Wshadow -Wunsafe-loop-optimizations \
 		   -ffunction-sections \
 		   -fdata-sections \
 		   -DSTM32F10X_MD \

--- a/include/mavlink.h
+++ b/include/mavlink.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-pedantic"
 #include <mavlink/v1.0/mavlink_types.h>
+#pragma GCC diagnostic pop
 
 #define MAVLINK_USE_CONVENIENCE_FUNCTIONS
 extern mavlink_system_t mavlink_system;


### PR DESCRIPTION
Just rather than turn off the "pedantic" warnings (issued when something does not conform to the specified standard, in this case ISO C99) for the whole project, only turn them off for the offending file that we have no control over (mavlink_types.h). That way we still get warnings if we do something stupid ourselves.